### PR TITLE
End to end test (to show how to use keys) plus dependency update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>net.i2p.crypto</groupId>
             <artifactId>eddsa</artifactId>
-            <version>0.2.0</version>
+            <version>0.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -38,26 +38,52 @@
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio</artifactId>
-            <version>1.14.0</version>
+            <version>1.14.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.1.0</version>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.1.0</version>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.1.0</version>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.21.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>1.2.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.2.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/test/java/org/paseto4j/PasetoTest.java
+++ b/src/test/java/org/paseto4j/PasetoTest.java
@@ -1,7 +1,13 @@
 package org.paseto4j;
 
 
+import net.i2p.crypto.eddsa.EdDSAPrivateKey;
 import net.i2p.crypto.eddsa.Utils;
+import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
+import net.i2p.crypto.eddsa.spec.EdDSAParameterSpec;
+import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,5 +47,19 @@ class PasetoTest {
         assertEquals(payload, Paseto.parse(publicKey, signedMessage, footer));
     }
 
+
+    @Test
+    public void end_to_end_test() {
+        byte[] seed = Utils.hexToBytes("b4cbfb45df4ce210d27d953e4a71f307fa19bb7d9f85341431d9e13b942a3774");
+        EdDSAParameterSpec parameterSpec   = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
+        EdDSAPrivateKeySpec privateKeySpec  = new EdDSAPrivateKeySpec(seed, parameterSpec);
+        EdDSAPrivateKey privateKey      = new EdDSAPrivateKey(privateKeySpec);
+        String              expectedPayload = "Payload";
+
+        String signed = Paseto.sign(seed, expectedPayload, "");
+        String actual = Paseto.parse(privateKey.getAbyte(), signed, "");
+
+        Assertions.assertEquals(expectedPayload, actual);
+    }
 
 }

--- a/src/test/java/org/paseto4j/PasetoTest.java
+++ b/src/test/java/org/paseto4j/PasetoTest.java
@@ -51,9 +51,9 @@ class PasetoTest {
     @Test
     public void end_to_end_test() {
         byte[] seed = Utils.hexToBytes("b4cbfb45df4ce210d27d953e4a71f307fa19bb7d9f85341431d9e13b942a3774");
-        EdDSAParameterSpec parameterSpec   = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
+        EdDSAParameterSpec  parameterSpec   = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         EdDSAPrivateKeySpec privateKeySpec  = new EdDSAPrivateKeySpec(seed, parameterSpec);
-        EdDSAPrivateKey privateKey      = new EdDSAPrivateKey(privateKeySpec);
+        EdDSAPrivateKey     privateKey      = new EdDSAPrivateKey(privateKeySpec);
         String              expectedPayload = "Payload";
 
         String signed = Paseto.sign(seed, expectedPayload, "");


### PR DESCRIPTION
I updated the dependency versions of net.i2p.crypto, okio, and Jupiter. I added the `maven-surefire-plugin` as a `<build>` plugin so that all tests would run with `mvn test`. I wrote an "end to end" test demonstrating how to use seeds/private keys with the library. More commits to come!