### PR TITLE
Support for paseto v4 (bouncycastle)

### DIFF
--- a/commons/src/main/java/org/paseto4j/commons/Version.java
+++ b/commons/src/main/java/org/paseto4j/commons/Version.java
@@ -3,7 +3,8 @@ package org.paseto4j.commons;
 public enum Version {
   V1("v1"),
   V2("v2"),
-  V3("v3");
+  V3("v3"),
+  V4("v4");
 
   private final String name;
 

--- a/commons/src/test/java/org/paseto4j/commons/TestVectors.java
+++ b/commons/src/test/java/org/paseto4j/commons/TestVectors.java
@@ -30,6 +30,9 @@ public class TestVectors {
     @JsonProperty("secret-key")
     private String secretKey;
 
+    @JsonProperty("secret-key-seed")
+    public String secretKeySeed;
+
     @JsonProperty("secret-key-pem")
     public String secretKeyPem;
 
@@ -44,6 +47,14 @@ public class TestVectors {
 
   public static List<TestVector> v3(Purpose purpose) throws IOException {
     return read(Version.V3).tests.stream()
+        .filter(
+            vector ->
+                purpose == Purpose.PURPOSE_LOCAL ? vector.key != null : vector.secretKeyPem != null)
+        .collect(Collectors.toList());
+  }
+
+  public static List<TestVector> v4(Purpose purpose) throws IOException {
+    return read(Version.V4).tests.stream()
         .filter(
             vector ->
                 purpose == Purpose.PURPOSE_LOCAL ? vector.key != null : vector.secretKeyPem != null)

--- a/commons/src/test/resources/test-vectors/v4.json
+++ b/commons/src/test/resources/test-vectors/v4.json
@@ -1,0 +1,187 @@
+{
+  "name": "PASETO v4 Test Vectors",
+  "tests": [
+    {
+      "name": "4-E-1",
+      "expect-fail": false,
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "nonce": "0000000000000000000000000000000000000000000000000000000000000000",
+      "token": "v4.local.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAr68PS4AXe7If_ZgesdkUMvSwscFlAl1pk5HC0e8kApeaqMfGo_7OpBnwJOAbY9V7WU6abu74MmcUE8YWAiaArVI8XJ5hOb_4v9RmDkneN0S92dx0OW4pgy7omxgf3S8c3LlQg",
+      "payload": "{\"data\":\"this is a secret message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "",
+      "implicit-assertion": ""
+    },
+    {
+      "name": "4-E-2",
+      "expect-fail": false,
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "nonce": "0000000000000000000000000000000000000000000000000000000000000000",
+      "token": "v4.local.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAr68PS4AXe7If_ZgesdkUMvS2csCgglvpk5HC0e8kApeaqMfGo_7OpBnwJOAbY9V7WU6abu74MmcUE8YWAiaArVI8XIemu9chy3WVKvRBfg6t8wwYHK0ArLxxfZP73W_vfwt5A",
+      "payload": "{\"data\":\"this is a hidden message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "",
+      "implicit-assertion": ""
+    },
+    {
+      "name": "4-E-3",
+      "expect-fail": false,
+      "nonce": "df654812bac492663825520ba2f6e67cf5ca5bdc13d4e7507a98cc4c2fcc3ad8",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t6-tyebyWG6Ov7kKvBdkrrAJ837lKP3iDag2hzUPHuMKA",
+      "payload": "{\"data\":\"this is a secret message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "",
+      "implicit-assertion": ""
+    },
+    {
+      "name": "4-E-4",
+      "expect-fail": false,
+      "nonce": "df654812bac492663825520ba2f6e67cf5ca5bdc13d4e7507a98cc4c2fcc3ad8",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WiA8rd3wgFSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t4gt6TiLm55vIH8c_lGxxZpE3AWlH4WTR0v45nsWoU3gQ",
+      "payload": "{\"data\":\"this is a hidden message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "",
+      "implicit-assertion": ""
+    },
+    {
+      "name": "4-E-5",
+      "expect-fail": false,
+      "nonce": "df654812bac492663825520ba2f6e67cf5ca5bdc13d4e7507a98cc4c2fcc3ad8",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t4x-RMNXtQNbz7FvFZ_G-lFpk5RG3EOrwDL6CgDqcerSQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+      "payload": "{\"data\":\"this is a secret message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}",
+      "implicit-assertion": ""
+    },
+    {
+      "name": "4-E-6",
+      "expect-fail": false,
+      "nonce": "df654812bac492663825520ba2f6e67cf5ca5bdc13d4e7507a98cc4c2fcc3ad8",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WiA8rd3wgFSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t6pWSA5HX2wjb3P-xLQg5K5feUCX4P2fpVK3ZLWFbMSxQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+      "payload": "{\"data\":\"this is a hidden message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}",
+      "implicit-assertion": ""
+    },
+    {
+      "name": "4-E-7",
+      "expect-fail": false,
+      "nonce": "df654812bac492663825520ba2f6e67cf5ca5bdc13d4e7507a98cc4c2fcc3ad8",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t40KCCWLA7GYL9KFHzKlwY9_RnIfRrMQpueydLEAZGGcA.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+      "payload": "{\"data\":\"this is a secret message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}",
+      "implicit-assertion": "{\"test-vector\":\"4-E-7\"}"
+    },
+    {
+      "name": "4-E-8",
+      "expect-fail": false,
+      "nonce": "df654812bac492663825520ba2f6e67cf5ca5bdc13d4e7507a98cc4c2fcc3ad8",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WiA8rd3wgFSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t5uvqQbMGlLLNYBc7A6_x7oqnpUK5WLvj24eE4DVPDZjw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+      "payload": "{\"data\":\"this is a hidden message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}",
+      "implicit-assertion": "{\"test-vector\":\"4-E-8\"}"
+    },
+    {
+      "name": "4-E-9",
+      "expect-fail": false,
+      "nonce": "df654812bac492663825520ba2f6e67cf5ca5bdc13d4e7507a98cc4c2fcc3ad8",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WiA8rd3wgFSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t6tybdlmnMwcDMw0YxA_gFSE_IUWl78aMtOepFYSWYfQA.YXJiaXRyYXJ5LXN0cmluZy10aGF0LWlzbid0LWpzb24",
+      "payload": "{\"data\":\"this is a hidden message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "arbitrary-string-that-isn't-json",
+      "implicit-assertion": "{\"test-vector\":\"4-E-9\"}"
+    },
+    {
+      "name": "4-S-1",
+      "expect-fail": false,
+      "public-key": "1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2",
+      "secret-key": "b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a37741eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2",
+      "secret-key-seed": "b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a3774",
+      "secret-key-pem": "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEILTL+0PfTOIQcn2VPkpxMwf6Gbt9n4UEFDjZ4RuUKjd0\n-----END PRIVATE KEY-----",
+      "public-key-pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAHrnbu7wEfAP9cGBOAHHwmH4Wsot1ciXBHwBBXQ4gsaI=\n-----END PUBLIC KEY-----",
+      "token": "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9bg_XBBzds8lTZShVlwwKSgeKpLT3yukTw6JUz3W4h_ExsQV-P0V54zemZDcAxFaSeef1QlXEFtkqxT1ciiQEDA",
+      "payload": "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "",
+      "implicit-assertion": ""
+    },
+    {
+      "name": "4-S-2",
+      "expect-fail": false,
+      "public-key": "1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2",
+      "secret-key": "b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a37741eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2",
+      "secret-key-seed": "b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a3774",
+      "secret-key-pem": "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEILTL+0PfTOIQcn2VPkpxMwf6Gbt9n4UEFDjZ4RuUKjd0\n-----END PRIVATE KEY-----",
+      "public-key-pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAHrnbu7wEfAP9cGBOAHHwmH4Wsot1ciXBHwBBXQ4gsaI=\n-----END PUBLIC KEY-----",
+      "token": "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+      "payload": "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}",
+      "implicit-assertion": ""
+    },
+    {
+      "name": "4-S-3",
+      "expect-fail": false,
+      "public-key": "1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2",
+      "secret-key": "b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a37741eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2",
+      "secret-key-seed": "b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a3774",
+      "secret-key-pem": "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEILTL+0PfTOIQcn2VPkpxMwf6Gbt9n4UEFDjZ4RuUKjd0\n-----END PRIVATE KEY-----",
+      "public-key-pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAHrnbu7wEfAP9cGBOAHHwmH4Wsot1ciXBHwBBXQ4gsaI=\n-----END PUBLIC KEY-----",
+      "token": "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9NPWciuD3d0o5eXJXG5pJy-DiVEoyPYWs1YSTwWHNJq6DZD3je5gf-0M4JR9ipdUSJbIovzmBECeaWmaqcaP0DQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+      "payload": "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+      "footer": "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}",
+      "implicit-assertion": "{\"test-vector\":\"4-S-3\"}"
+    },
+    {
+      "name": "4-F-1",
+      "expect-fail": true,
+      "public-key": "1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2",
+      "secret-key": "b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a37741eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2",
+      "secret-key-seed": "b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a3774",
+      "secret-key-pem": "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEILTL+0PfTOIQcn2VPkpxMwf6Gbt9n4UEFDjZ4RuUKjd0\n-----END PRIVATE KEY-----",
+      "public-key-pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAHrnbu7wEfAP9cGBOAHHwmH4Wsot1ciXBHwBBXQ4gsaI=\n-----END PUBLIC KEY-----",
+      "token": "v4.local.vngXfCISbnKgiP6VWGuOSlYrFYU300fy9ijW33rznDYgxHNPwWluAY2Bgb0z54CUs6aYYkIJ-bOOOmJHPuX_34Agt_IPlNdGDpRdGNnBz2MpWJvB3cttheEc1uyCEYltj7wBQQYX.YXJiaXRyYXJ5LXN0cmluZy10aGF0LWlzbid0LWpzb24",
+      "payload": null,
+      "footer": "arbitrary-string-that-isn't-json",
+      "implicit-assertion": "{\"test-vector\":\"4-F-1\"}"
+    },
+    {
+      "name": "4-F-2",
+      "expect-fail": true,
+      "nonce": "df654812bac492663825520ba2f6e67cf5ca5bdc13d4e7507a98cc4c2fcc3ad8",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v4.public.eyJpbnZhbGlkIjoidGhpcyBzaG91bGQgbmV2ZXIgZGVjb2RlIn22Sp4gjCaUw0c7EH84ZSm_jN_Qr41MrgLNu5LIBCzUr1pn3Z-Wukg9h3ceplWigpoHaTLcwxj0NsI1vjTh67YB.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+      "payload": null,
+      "footer": "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}",
+      "implicit-assertion": "{\"test-vector\":\"4-F-2\"}"
+    },
+    {
+      "name": "4-F-3",
+      "expect-fail": true,
+      "nonce": "26f7553354482a1d91d4784627854b8da6b8042a7966523c2b404e8dbbe7f7f2",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v3.local.23e_2PiqpQBPvRFKzB0zHhjmxK3sKo2grFZRRLM-U7L0a8uHxuF9RlVz3Ic6WmdUUWTxCaYycwWV1yM8gKbZB2JhygDMKvHQ7eBf8GtF0r3K0Q_gF1PXOxcOgztak1eD1dPe9rLVMSgR0nHJXeIGYVuVrVoLWQ.YXJiaXRyYXJ5LXN0cmluZy10aGF0LWlzbid0LWpzb24",
+      "payload": null,
+      "footer": "arbitrary-string-that-isn't-json",
+      "implicit-assertion": "{\"test-vector\":\"4-F-3\"}"
+    },
+    {
+      "name": "4-F-4",
+      "expect-fail": true,
+      "nonce": "df654812bac492663825520ba2f6e67cf5ca5bdc13d4e7507a98cc4c2fcc3ad8",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v4.local.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAr68PS4AXe7If_ZgesdkUMvSwscFlAl1pk5HC0e8kApeaqMfGo_7OpBnwJOAbY9V7WU6abu74MmcUE8YWAiaArVI8XJ5hOb_4v9RmDkneN0S92dx0OW4pgy7omxgf3S8c3LlQh",
+      "payload": null,
+      "footer": "",
+      "implicit-assertion": ""
+    },
+    {
+      "name": "4-F-5",
+      "expect-fail": true,
+      "nonce": "df654812bac492663825520ba2f6e67cf5ca5bdc13d4e7507a98cc4c2fcc3ad8",
+      "key": "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+      "token": "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t4x-RMNXtQNbz7FvFZ_G-lFpk5RG3EOrwDL6CgDqcerSQ==.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+      "payload": null,
+      "footer": "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}",
+      "implicit-assertion": ""
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <module>version1</module>
         <module>version2</module>
         <module>version3</module>
+        <module>version4</module>
     </modules>
 
     <scm>

--- a/version4/LICENSE.txt
+++ b/version4/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 - 2024, Nanne Baars
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/version4/pom.xml
+++ b/version4/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.nbaars</groupId>
+        <artifactId>paseto4j</artifactId>
+        <version>2024.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>paseto4j-version4</artifactId>
+
+    <name>paseto4j-version4</name>
+
+    <properties>
+        <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.nbaars</groupId>
+            <artifactId>paseto4j-commons</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tuweni</groupId>
+            <artifactId>tuweni-bytes</artifactId>
+            <version>2.3.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.nbaars</groupId>
+            <artifactId>paseto4j-commons</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/version4/src/main/java/org/paseto4j/version4/CryptoFunctions.java
+++ b/version4/src/main/java/org/paseto4j/version4/CryptoFunctions.java
@@ -1,0 +1,56 @@
+package org.paseto4j.version4;
+
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.digests.Blake2bDigest;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
+
+public class CryptoFunctions {
+  private CryptoFunctions() {}
+
+  public static byte[] xchacha20(byte[] message, byte[] nonce, byte[] key) {
+    XChaCha20Engine engine = new XChaCha20Engine();
+
+    engine.init(true, new ParametersWithIV(new KeyParameter(key), nonce));
+    byte[] out = new byte[message.length];
+
+    engine.processBytes(message, 0, message.length, out, 0);
+
+    return out;
+  }
+
+  public static byte[] blake2b(int size, byte[] message, byte[] key) {
+    Digest digest = new Blake2bDigest(key, size, null, null);
+    byte[] out = new byte[size];
+    digest.update(message, 0, message.length);
+    digest.doFinal(out, 0);
+    return out;
+  }
+
+  public static byte[] sign(PrivateKey privateKey, byte[] msg) {
+    try {
+      Signature signature = Signature.getInstance("Ed25519", "BC");
+      signature.initSign(privateKey);
+      signature.update(msg);
+      return signature.sign();
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public static boolean verify(PublicKey publicKey, byte[] msg, byte[] signature) {
+    try {
+      Signature verifier = Signature.getInstance("Ed25519", "BC");
+      verifier.initVerify(publicKey);
+      verifier.update(msg);
+
+      return verifier.verify(signature);
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/version4/src/main/java/org/paseto4j/version4/Paseto.java
+++ b/version4/src/main/java/org/paseto4j/version4/Paseto.java
@@ -1,0 +1,85 @@
+package org.paseto4j.version4;
+
+import java.security.SignatureException;
+import org.paseto4j.commons.PrivateKey;
+import org.paseto4j.commons.PublicKey;
+import org.paseto4j.commons.SecretKey;
+
+public class Paseto {
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#encrypt
+   */
+  public static String encrypt(SecretKey key, String payload, String footer) {
+    return PasetoLocal.encrypt(key, payload, footer, "");
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#encrypt
+   */
+  public static String encrypt(
+      SecretKey key, String payload, String footer, String implicitAssertion) {
+    return PasetoLocal.encrypt(key, payload, footer, implicitAssertion);
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#decrypt
+   */
+  public static String decrypt(SecretKey key, String signedMessage, String footer) {
+    return PasetoLocal.decrypt(key, signedMessage, footer);
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#sign
+   */
+  public static String decrypt(
+      SecretKey key, String signedMessage, String footer, String implicitAssertion) {
+    return PasetoLocal.decrypt(key, signedMessage, footer, implicitAssertion);
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#sign
+   */
+  public static String sign(PrivateKey privateKey, String payload) {
+    return sign(privateKey, payload, "");
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#sign
+   */
+  public static String sign(PrivateKey privateKey, String payload, String footer) {
+    return sign(privateKey, payload, footer, "");
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#sign
+   */
+  public static String sign(
+      PrivateKey privateKey, String payload, String footer, String implicitAssertion) {
+    return PasetoPublic.sign(privateKey, payload, footer, implicitAssertion);
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#verify
+   */
+  public static String parse(PublicKey publicKey, String signedMessage) throws SignatureException {
+    return parse(publicKey, signedMessage, "");
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#verify
+   */
+  public static String parse(PublicKey publicKey, String signedMessage, String footer)
+      throws SignatureException {
+    return parse(publicKey, signedMessage, footer, "");
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#verify
+   */
+  public static String parse(
+      PublicKey publicKey, String signedMessage, String footer, String implicitAssertion)
+      throws SignatureException {
+    return PasetoPublic.parse(publicKey, signedMessage, footer, implicitAssertion);
+  }
+}

--- a/version4/src/main/java/org/paseto4j/version4/PasetoLocal.java
+++ b/version4/src/main/java/org/paseto4j/version4/PasetoLocal.java
@@ -1,0 +1,120 @@
+package org.paseto4j.version4;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Base64.getUrlDecoder;
+import static java.util.Objects.requireNonNull;
+import static org.paseto4j.commons.ByteUtils.concat;
+import static org.paseto4j.commons.Conditions.verify;
+import static org.paseto4j.commons.Purpose.PURPOSE_LOCAL;
+import static org.paseto4j.commons.Version.V4;
+
+import java.security.MessageDigest;
+import java.util.Arrays;
+import org.apache.tuweni.bytes.Bytes;
+import org.paseto4j.commons.PreAuthenticationEncoder;
+import org.paseto4j.commons.SecretKey;
+import org.paseto4j.commons.Token;
+import org.paseto4j.commons.TokenOut;
+
+public class PasetoLocal {
+  private PasetoLocal() {}
+
+  public static String encrypt(SecretKey key, String payload, String footer, String implicit) {
+    return encrypt(key, Bytes.random(32).toArray(), payload, footer, implicit);
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#encrypt
+   */
+  static String encrypt(
+      SecretKey key, byte[] nonce, String payload, String footer, String implicitAssertion) {
+    requireNonNull(key);
+    requireNonNull(payload);
+    verify(key.isValidFor(V4, PURPOSE_LOCAL), "Key is not valid for purpose and version");
+    verify(key.hasLength(32), "key should be 32 bytes");
+    verify(nonce.length == 32, "nonce should be 32 bytes");
+
+    TokenOut token = new TokenOut(V4, PURPOSE_LOCAL);
+
+    // 4
+    byte[] tmp = encryptionKey(key, nonce);
+    byte[] ek = Arrays.copyOfRange(tmp, 0, 32);
+    byte[] n2 = Arrays.copyOfRange(tmp, 32, 56);
+    byte[] ak = authenticationKey(key, nonce);
+
+    // 5
+    byte[] c = CryptoFunctions.xchacha20(payload.getBytes(UTF_8), n2, ek);
+
+    // 6
+    byte[] preAuth =
+        PreAuthenticationEncoder.encode(
+            token.header(), nonce, c, footer.getBytes(UTF_8), implicitAssertion.getBytes(UTF_8));
+
+    // 7
+    byte[] t = CryptoFunctions.blake2b(32, preAuth, ak);
+
+    return token.payload(concat(nonce, c, t)).footer(footer).doFinal();
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#decrypt
+   */
+  public static String decrypt(SecretKey key, String token, String footer) {
+    return decrypt(key, token, footer, "");
+  }
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#decrypt
+   */
+  static String decrypt(SecretKey key, String token, String footer, String implicitAssertion) {
+    requireNonNull(key);
+    requireNonNull(token);
+
+    verify(key.isValidFor(V4, PURPOSE_LOCAL), "Key is not valid for purpose and version");
+    verify(key.hasLength(32), "key should be 32 bytes");
+
+    Token pasetoToken = new Token(token, V4, PURPOSE_LOCAL, footer);
+
+    // 4
+    byte[] nct = getUrlDecoder().decode(pasetoToken.getPayload());
+    byte[] nonce = Arrays.copyOfRange(nct, 0, 32);
+    byte[] t = Arrays.copyOfRange(nct, nct.length - 32, nct.length);
+    byte[] c = Arrays.copyOfRange(nct, 32, nct.length - 32);
+
+    // 5
+    byte[] tmp = encryptionKey(key, nonce);
+    byte[] ek = Arrays.copyOfRange(tmp, 0, 32);
+    byte[] n2 = Arrays.copyOfRange(tmp, 32, 56);
+    byte[] ak = authenticationKey(key, nonce);
+
+    // 6
+    byte[] preAuth =
+        PreAuthenticationEncoder.encode(
+            pasetoToken.header(),
+            nonce,
+            c,
+            footer.getBytes(UTF_8),
+            implicitAssertion.getBytes(UTF_8));
+
+    // 7
+    byte[] t2 = CryptoFunctions.blake2b(32, preAuth, ak);
+
+    // 8
+    if (!MessageDigest.isEqual(t, t2)) {
+      throw new IllegalStateException("HMAC verification failed");
+    }
+
+    byte[] message = CryptoFunctions.xchacha20(c, n2, ek);
+
+    return new String(message, UTF_8);
+  }
+
+  private static byte[] encryptionKey(SecretKey key, byte[] nonce) {
+    return CryptoFunctions.blake2b(
+        56, concat("paseto-encryption-key".getBytes(UTF_8), nonce), key.getMaterial());
+  }
+
+  private static byte[] authenticationKey(SecretKey key, byte[] nonce) {
+    return CryptoFunctions.blake2b(
+        32, concat("paseto-auth-key-for-aead".getBytes(UTF_8), nonce), key.getMaterial());
+  }
+}

--- a/version4/src/main/java/org/paseto4j/version4/PasetoPublic.java
+++ b/version4/src/main/java/org/paseto4j/version4/PasetoPublic.java
@@ -1,0 +1,79 @@
+package org.paseto4j.version4;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Base64.getUrlDecoder;
+import static java.util.Objects.requireNonNull;
+import static org.paseto4j.commons.ByteUtils.concat;
+import static org.paseto4j.commons.Conditions.verify;
+import static org.paseto4j.commons.Purpose.PURPOSE_PUBLIC;
+import static org.paseto4j.commons.Version.V4;
+
+import java.security.SignatureException;
+import java.util.Arrays;
+import org.paseto4j.commons.*;
+
+public class PasetoPublic {
+  private PasetoPublic() {}
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#sign
+   */
+  static String sign(
+      PrivateKey privateKey, String payload, String footer, String implicitAssertion) {
+
+    requireNonNull(privateKey);
+    requireNonNull(payload);
+    verify(privateKey.isValidFor(V4, PURPOSE_PUBLIC), "Key is not valid for purpose and version");
+
+    TokenOut token = new TokenOut(V4, PURPOSE_PUBLIC);
+
+    // 3
+    byte[] m2 =
+        PreAuthenticationEncoder.encode(
+            token.header(),
+            payload.getBytes(UTF_8),
+            footer.getBytes(UTF_8),
+            implicitAssertion.getBytes(UTF_8));
+
+    // 4
+    byte[] signature = CryptoFunctions.sign(privateKey.getKey(), m2);
+
+    return token.payload(concat(payload.getBytes(UTF_8), signature)).footer(footer).doFinal();
+  }
+
+  /**
+   * https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#verify
+   */
+  public static String parse(
+      PublicKey publicKey, String signedMessage, String footer, String implicitAssertion)
+      throws SignatureException {
+    requireNonNull(publicKey);
+    requireNonNull(signedMessage);
+    verify(publicKey.isValidFor(V4, PURPOSE_PUBLIC), "Key is not valid for purpose and version");
+
+    // 1 and 2
+    Token token = new Token(signedMessage, V4, PURPOSE_PUBLIC, footer);
+
+    // 4
+    byte[] sm = getUrlDecoder().decode(token.getPayload());
+    byte[] signature = Arrays.copyOfRange(sm, sm.length - 64, sm.length);
+    byte[] message = Arrays.copyOfRange(sm, 0, sm.length - 64);
+
+    // 5
+    byte[] m2 =
+        PreAuthenticationEncoder.encode(
+            token.header(), message, footer.getBytes(UTF_8), implicitAssertion.getBytes(UTF_8));
+
+    // 6
+    verifySignature(publicKey, m2, signature);
+
+    return new String(message, UTF_8);
+  }
+
+  private static void verifySignature(PublicKey key, byte[] m2, byte[] signature)
+      throws SignatureException {
+    if (!CryptoFunctions.verify(key.getKey(), m2, signature)) {
+      throw new SignatureException("Invalid signature");
+    }
+  }
+}

--- a/version4/src/main/java/org/paseto4j/version4/XChaCha20Engine.java
+++ b/version4/src/main/java/org/paseto4j/version4/XChaCha20Engine.java
@@ -1,0 +1,85 @@
+package org.paseto4j.version4;
+
+import org.bouncycastle.crypto.engines.ChaChaEngine;
+import org.bouncycastle.util.Pack;
+
+/** Taken from dangling PR https://github.com/bcgit/bc-java/pull/957 */
+public class XChaCha20Engine extends ChaChaEngine {
+
+  /** Create a new XChaCha20 engine. */
+  public XChaCha20Engine() {
+    super();
+  }
+
+  @Override
+  public String getAlgorithmName() {
+    return "XChaCha20";
+  }
+
+  @Override
+  protected int getNonceSize() {
+    return 24;
+  }
+
+  @Override
+  protected void setKey(byte[] keyBytes, byte[] ivBytes) {
+    if (keyBytes == null) {
+      throw new IllegalArgumentException(
+          getAlgorithmName() + " doesn't support re-init with null key");
+    }
+
+    if (keyBytes.length != 32) {
+      throw new IllegalStateException(getAlgorithmName() + " requires a 256 bit key");
+    }
+
+    // Derive sub key using the HChaCha algorithm and set copy it to the engine state
+    int[] subKey = hChaChaDeriveSubKey(keyBytes, ivBytes);
+    System.arraycopy(subKey, 0, engineState, 4, subKey.length);
+
+    // Use last 64 bits of input IV as nonce for ChaCha20
+    Pack.littleEndianToInt(ivBytes, 16, engineState, 14, 2);
+  }
+
+  public int[] hChaChaDeriveSubKey(byte[] keyBytes, byte[] ivBytes) {
+    if (keyBytes == null) {
+      throw new IllegalArgumentException("HChaCha" + rounds + " doesn't support null keys");
+    }
+
+    if (keyBytes.length != 32) {
+      throw new IllegalStateException("HChaCha" + rounds + "  requires a 256 bit key");
+    }
+
+    if (ivBytes == null) {
+      throw new IllegalArgumentException("HChaCha" + rounds + "  needs a non-null IV");
+    }
+
+    if (ivBytes.length < 16) {
+      throw new IllegalArgumentException("HChaCha" + rounds + " needs an at least 128 bit nonce");
+    }
+
+    // Set key for HChaCha20
+    super.setKey(keyBytes, ivBytes);
+    Pack.littleEndianToInt(ivBytes, 0, engineState, 12, 4);
+
+    // Process engine state to generate ChaCha20 key
+    int[] hchacha20Out = new int[engineState.length];
+    chachaCore(20, engineState, hchacha20Out);
+
+    // Take first and last 128 bits of output as the sub key
+    int[] subkey = new int[8];
+    System.arraycopy(hchacha20Out, 0, subkey, 0, 4);
+    System.arraycopy(hchacha20Out, 12, subkey, 4, 4);
+
+    // Remove addition in final round of chachaCore
+    subkey[0] -= engineState[0];
+    subkey[1] -= engineState[1];
+    subkey[2] -= engineState[2];
+    subkey[3] -= engineState[3];
+    subkey[4] -= engineState[12];
+    subkey[5] -= engineState[13];
+    subkey[6] -= engineState[14];
+    subkey[7] -= engineState[15];
+
+    return subkey;
+  }
+}

--- a/version4/src/test/java/org/paseto4j/version4/PasetoLocalTest.java
+++ b/version4/src/test/java/org/paseto4j/version4/PasetoLocalTest.java
@@ -1,0 +1,97 @@
+package org.paseto4j.version4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.paseto4j.commons.HexToBytes.hexToBytes;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.paseto4j.commons.Purpose;
+import org.paseto4j.commons.SecretKey;
+import org.paseto4j.commons.TestVectors;
+import org.paseto4j.commons.Version;
+
+public class PasetoLocalTest {
+  private static Stream<Arguments> testVectors() throws IOException {
+    return TestVectors.v4(Purpose.PURPOSE_LOCAL).stream()
+        .map(
+            test ->
+                Arguments.of(
+                    test.name,
+                    test.expectFail,
+                    test.key,
+                    test.nonce,
+                    test.payload,
+                    test.footer,
+                    test.implicitAssertion,
+                    test.token));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testVectors")
+  void encryptTestVectors(
+      String name,
+      boolean expectFail,
+      String key,
+      String nonce,
+      String payload,
+      String footer,
+      String implicitAssertion,
+      String expectedToken) {
+    if (expectFail) {
+      assertThrows(
+          Exception.class,
+          () ->
+              PasetoLocal.encrypt(
+                  new SecretKey(hexToBytes(key), Version.V4),
+                  hexToBytes(nonce),
+                  payload,
+                  footer,
+                  implicitAssertion));
+    } else {
+      assertEquals(
+          expectedToken,
+          PasetoLocal.encrypt(
+              new SecretKey(hexToBytes(key), Version.V4),
+              hexToBytes(nonce),
+              payload,
+              footer,
+              implicitAssertion));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("testVectors")
+  void decryptTestVectors(
+      String name,
+      boolean expectFail,
+      String key,
+      String nonce,
+      String payload,
+      String footer,
+      String implicitAssertion,
+      String encryptedToken) {
+    if (expectFail) {
+      assertThrows(
+          Exception.class,
+          () ->
+              PasetoLocal.encrypt(
+                  new SecretKey(hexToBytes(key), Version.V4),
+                  hexToBytes(nonce),
+                  payload,
+                  footer,
+                  implicitAssertion));
+    } else {
+      assertEquals(
+          payload,
+          PasetoLocal.decrypt(
+              new SecretKey(hexToBytes(key), Version.V4),
+              encryptedToken,
+              footer,
+              implicitAssertion));
+    }
+  }
+}

--- a/version4/src/test/java/org/paseto4j/version4/PasetoPublicTest.java
+++ b/version4/src/test/java/org/paseto4j/version4/PasetoPublicTest.java
@@ -1,0 +1,99 @@
+package org.paseto4j.version4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.paseto4j.commons.Version.V4;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.security.Security;
+import java.security.SignatureException;
+import java.util.stream.Stream;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.paseto4j.commons.PrivateKey;
+import org.paseto4j.commons.PublicKey;
+import org.paseto4j.commons.Purpose;
+import org.paseto4j.commons.TestVectors;
+
+public class PasetoPublicTest {
+  static {
+    Security.addProvider(new BouncyCastleProvider());
+  }
+
+  private static Stream<Arguments> testVectors() throws IOException {
+    return TestVectors.v4(Purpose.PURPOSE_PUBLIC).stream()
+        .map(
+            test ->
+                Arguments.of(
+                    test.name,
+                    test.expectFail,
+                    test.publicKeyPem,
+                    test.secretKeyPem,
+                    test.payload,
+                    test.footer,
+                    test.implicitAssertion,
+                    test.token));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testVectors")
+  void signTestVectors(
+      String name,
+      boolean expectFail,
+      String publicKeyPem,
+      String secretKeyPem,
+      String payload,
+      String footer,
+      String implicitAssertion,
+      String expectedToken)
+      throws IOException, SignatureException {
+    Reader rdr = new StringReader(secretKeyPem);
+    Object parsed = new PEMParser(rdr).readObject();
+    var edPrivateKey = new JcaPEMKeyConverter().getPrivateKey((PrivateKeyInfo) parsed);
+    var privateKey = new PrivateKey(edPrivateKey, V4);
+
+    if (expectFail) {
+      assertThrows(
+          Exception.class, () -> PasetoPublic.sign(privateKey, payload, footer, implicitAssertion));
+    } else {
+      assertEquals(
+          expectedToken, PasetoPublic.sign(privateKey, payload, footer, implicitAssertion));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("testVectors")
+  void parseTestVectors(
+      String name,
+      boolean expectFail,
+      String publicKeyPem,
+      String secretKeyPem,
+      String payload,
+      String footer,
+      String implicitAssertion,
+      String expectedToken)
+      throws IOException, SignatureException {
+    Reader rdr = new StringReader(publicKeyPem);
+    Object parsed = new PEMParser(rdr).readObject();
+    System.out.println(parsed);
+    var edPublicKey = new JcaPEMKeyConverter().getPublicKey((SubjectPublicKeyInfo) parsed);
+    var publicKey = new PublicKey(edPublicKey, V4);
+
+    if (expectFail) {
+      assertThrows(
+          Exception.class,
+          () -> PasetoPublic.parse(publicKey, expectedToken, footer, implicitAssertion));
+    } else {
+      assertEquals(
+          payload, PasetoPublic.parse(publicKey, expectedToken, footer, implicitAssertion));
+    }
+  }
+}


### PR DESCRIPTION
Addresses #32

There is the still open issue with XChaCha20 that I circumvented by extracting the class from the still open PR in bouncycastle. This should be easily removable once (if?) the PR is ever merged.
It should be somewhat save to do this since it only tweaks the parameters for the core algorithm.

It is possible to use libsodium instead, but the required `crypto_stream_xchacha20_xor` function is not public which would require another rather ugly workaround.